### PR TITLE
Fix dashboard layout and caratula sync

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { CaratulaProvider, useCaratula } from './context/CaratulaContext';
+import { useCaratula } from './context/CaratulaContext';
 import './App.css';
 
 import Paso from './components/pages/paso';
@@ -8,9 +8,8 @@ import MainLayout from './components/pages/MainLayout';
 
 function App() {
   return (
-    <CaratulaProvider>
-      <BrowserRouter>
-        <Routes>
+    <BrowserRouter>
+      <Routes>
           {/* Redirección inicial */}
           <Route path="/" element={<RedirectSegunCaratula />} />
 
@@ -24,7 +23,6 @@ function App() {
           <Route path="*" element={<RedirectSegunCaratula />} />
         </Routes>
       </BrowserRouter>
-    </CaratulaProvider>
   );
 }
 

--- a/src/components/CaratulaActivaBanner.jsx
+++ b/src/components/CaratulaActivaBanner.jsx
@@ -1,7 +1,9 @@
-import { useCabecera } from '@/hooks/useCabecera';
+import { useCaratula } from '@/context/CaratulaContext';
 
 export default function CaratulaActivaBanner() {
-  const { hogar, mes, expediente } = useCabecera();
+  const { caratula } = useCaratula();
+  if (!caratula) return null;
+  const { hogar, mes, expediente } = caratula;
 
   return (
     <div className="bg-blue-100 text-blue-800 px-4 py-2 rounded shadow text-sm mb-4">

--- a/src/components/pages/paso1.jsx
+++ b/src/components/pages/paso1.jsx
@@ -95,6 +95,7 @@ Servicio solicitado: ${datos.servicio || '—'}
     const limpio = normalizarForm(form);
     localStorage.setItem(`cabecera_${limpio.hogar}_${limpio.mes}`, JSON.stringify(limpio));
     seleccionarCaratula(limpio);
+    localStorage.setItem('caratula_activa', JSON.stringify(limpio));
     setTexto(generarTexto(limpio));
     cargarCaratulasValidas();
   };
@@ -103,6 +104,7 @@ Servicio solicitado: ${datos.servicio || '—'}
   const borrar = () => {
     localStorage.removeItem(claveActual);
     limpiarCaratula();
+    localStorage.removeItem('caratula_activa');
     const limpio = normalizarForm(null);
     setForm(limpio);
     setTexto('');
@@ -117,6 +119,7 @@ Servicio solicitado: ${datos.servicio || '—'}
     setForm(limpio);
     setTexto(generarTexto(limpio));
     seleccionarCaratula(limpio);
+    localStorage.setItem('caratula_activa', JSON.stringify(limpio));
   };
 
   // Permite limpiar cualquier entrada inválida en localStorage

--- a/src/components/pages/paso3.jsx
+++ b/src/components/pages/paso3.jsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/select';
 import { useEmailContext } from '@/context/EmailContext';
 import { usePasoKey } from '@/hooks/usePasoKey';
-import { useCabecera } from '@/hooks/useCabecera';
+import { useCaratula } from '@/context/CaratulaContext';
 import CaratulaActivaBanner from '@/components/CaratulaActivaBanner';
 
 /**
@@ -58,7 +58,8 @@ export default function Paso3() {
   // Clave específica para Paso 3 (incluye hogar + mes gestionado por useCaratula())
   const STORAGE_KEY = usePasoKey(3);
   const { setUltimaFechaMailPaso3 } = useEmailContext();
-  const { mes } = useCabecera(); // Ahora obtenemos “mes” en lugar de un inexistente “periodo”
+  const { caratula } = useCaratula();
+  const mes = caratula?.mes || '';
 
   // ------------- Estado local -------------
   const [form, setForm] = useState({

--- a/src/components/pages/paso5.jsx
+++ b/src/components/pages/paso5.jsx
@@ -1,7 +1,7 @@
 // src/components/formularios/Paso5.jsx
 
 import React, { useState, useEffect } from 'react'
-import { useCabecera } from '@/hooks/useCabecera'
+import { useCaratula } from '@/context/CaratulaContext'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import PresupuestoPdfRichard from '@/components/PresupuestoPdfRichard.jsx'
@@ -46,8 +46,10 @@ function formatoPeriodo(mes) {
 }
 
 export default function Paso5() {
-  // Obtenemos del contexto la carátula activa: { hogar, mes, expediente, remito, monto, servicio }
-  const { mes, hogar } = useCabecera()
+  // Obtenemos del contexto la carátula activa
+  const { caratula } = useCaratula()
+  const mes = caratula?.mes || ''
+  const hogar = caratula?.hogar || ''
 
   // Si mes === "abril2025", fechaInicial será "2025-04-01"
   const fechaInicial = fechaInicioDelMes(mes)

--- a/src/context/CaratulaContext.jsx
+++ b/src/context/CaratulaContext.jsx
@@ -5,22 +5,32 @@ import { createContext, useContext, useState } from 'react';
 export const CaratulaContext = createContext(null);
 
 export function CaratulaProvider({ children }) {
-  // { hogar, mes, expediente, servicio }
-  const [caratula, setCaratula] = useState(null);
+  // Estado inicial: intenta leer la carátula activa del localStorage
+  const [caratula, setCaratula] = useState(() => {
+    try {
+      const raw = localStorage.getItem('caratula_activa');
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  });
 
   // Función para “activar” una carátula concreta
   const seleccionarCaratula = (datos) => {
-    setCaratula({
+    const activa = {
       hogar: datos.hogar,
       mes: datos.mes,
       expediente: datos.expediente,
       servicio: datos.servicio || '',
-    });
+    };
+    setCaratula(activa);
+    localStorage.setItem('caratula_activa', JSON.stringify(activa));
   };
 
   // Función para “desactivar” o limpiar la carátula
   const limpiarCaratula = () => {
     setCaratula(null);
+    localStorage.removeItem('caratula_activa');
   };
 
   return (


### PR DESCRIPTION
## Summary
- persist active caratula in context
- drop duplicate CaratulaProvider in App.jsx
- show active caratula banner from context
- ensure steps use CaratulaContext for period selection

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840e53a7d048332929d69d322ee0e65