### PR TITLE
Use useCabecera hook across steps

### DIFF
--- a/src/components/CaratulaActivaBanner.jsx
+++ b/src/components/CaratulaActivaBanner.jsx
@@ -1,9 +1,8 @@
-import { useCaratula } from '@/context/CaratulaContext';
+import { useCabecera } from '@/hooks/useCabecera';
 
 export default function CaratulaActivaBanner() {
-  const { caratula } = useCaratula();
-  if (!caratula) return null;
-  const { hogar, mes, expediente } = caratula;
+  const { hogar, mes, expediente } = useCabecera();
+  if (!hogar || !mes) return null;
 
   return (
     <div className="bg-blue-100 text-blue-800 px-4 py-2 rounded shadow text-sm mb-4">

--- a/src/components/pages/paso3.jsx
+++ b/src/components/pages/paso3.jsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/select';
 import { useEmailContext } from '@/context/EmailContext';
 import { usePasoKey } from '@/hooks/usePasoKey';
-import { useCaratula } from '@/context/CaratulaContext';
+import { useCabecera } from '@/hooks/useCabecera';
 import CaratulaActivaBanner from '@/components/CaratulaActivaBanner';
 
 /**
@@ -55,11 +55,10 @@ const empresas = [
 ];
 
 export default function Paso3() {
-  // Clave específica para Paso 3 (incluye hogar + mes gestionado por useCaratula())
+  // Clave específica para Paso 3 (incluye hogar + mes obtenido de useCabecera())
   const STORAGE_KEY = usePasoKey(3);
   const { setUltimaFechaMailPaso3 } = useEmailContext();
-  const { caratula } = useCaratula();
-  const mes = caratula?.mes || '';
+  const { mes, expediente } = useCabecera();
 
   // ------------- Estado local -------------
   const [form, setForm] = useState({
@@ -79,7 +78,13 @@ export default function Paso3() {
     if (saved) {
       try {
         const parsed = JSON.parse(saved);
-        if (parsed.form) setForm(parsed.form);
+        if (parsed.form) {
+          const formData = { ...parsed.form };
+          if (formData.periodo && !formData.periodo.includes(' ')) {
+            formData.periodo = formatoPeriodo(formData.periodo);
+          }
+          setForm(formData);
+        }
         if (parsed.emails) setEmails(parsed.emails);
         if (parsed.texto) setTexto(parsed.texto);
       } catch (err) {

--- a/src/components/pages/paso8.jsx
+++ b/src/components/pages/paso8.jsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { useCaratula } from '@/context/CaratulaContext'
+import { useCabecera } from '@/hooks/useCabecera'
 import { usePasoKey } from '@/hooks/usePasoKey'
 import CaratulaActivaBanner from '@/components/CaratulaActivaBanner'
 
@@ -19,29 +19,8 @@ function formatoPeriodo(mes) {
 }
 
 export default function Paso8() {
-  // ----------- 1) Obtenemos la carátula activa ----------- 
-  // useCaratula() devuelve { hogar, mes, expediente, remito, monto, servicio } o null si no hay carátula
-  const { caratula } = useCaratula()  
-
-  // Si no hay carátula, mostramos mensaje para que el usuario vaya a Paso 1
-  if (!caratula) {
-    return (
-      <div className="p-10 text-center space-y-6">
-        <h2 className="text-xl font-semibold text-gray-700">
-          No hay una carátula activa seleccionada
-        </h2>
-        <p className="text-gray-500">
-          Debés crear o activar una carátula en el Paso 1 antes de continuar.
-        </p>
-        <Button onClick={() => window.location.assign('/paso/1')}>
-          Ir a Paso 1
-        </Button>
-      </div>
-    )
-  }
-
-  // ----------- 2) Obtenemos datos de la carátula ----------- 
-  const { expediente: expCaratula, servicio: servCaratula, hogares: hogaresCaratula, mes: mesCaratula } = caratula
+  // ----------- 1) Obtenemos la cabecera activa -----------
+  const { expediente: expCaratula, servicio: servCaratula, hogares: hogaresCaratula, mes: mesCaratula } = useCabecera()
 
   // Convertimos "abril2025" → "ABRIL 2025"
   const periodoInicial = formatoPeriodo(mesCaratula)
@@ -65,12 +44,16 @@ export default function Paso8() {
     if (saved) {
       try {
         const parsed = JSON.parse(saved)
-        setForm(parsed)
+        const datos = { ...parsed }
+        if (datos.periodo && !datos.periodo.includes(' ')) {
+          datos.periodo = formatoPeriodo(datos.periodo)
+        }
+        setForm(datos)
       } catch (err) {
         console.error('Error al cargar Paso 8 desde localStorage:', err)
       }
     } else {
-      // si no hay guardado, asegurarse de poblar con datos de la carátula
+      // si no hay guardado, asegurarse de poblar con datos de la cabecera
       setForm({
         expediente: expCaratula || '',
         servicio: servCaratula || '',
@@ -110,7 +93,7 @@ Se remite a los fines de su prosecución.
 
   return (
     <div className="space-y-6 max-w-3xl mx-auto">
-      {/* Banner que muestra cuál es la carátula activa */}
+      {/* Banner que muestra cuál es la cabecera activa */}
       <CaratulaActivaBanner />
 
       {/* Formulario */}

--- a/src/hooks/usePasoKey.js
+++ b/src/hooks/usePasoKey.js
@@ -1,10 +1,9 @@
-import { useCaratula } from '@/context/CaratulaContext';
+import { useCabecera } from '@/hooks/useCabecera';
 
 export function usePasoKey(numeroPaso) {
-  const { caratula } = useCaratula();
+  const { mes, hogar } = useCabecera();
 
-  const mes = (caratula?.mes || '').toLowerCase().replace(/\s+/g, '');
-  const hogar = (caratula?.hogar || '').toLowerCase().replace(/\s+/g, '');
-
-  return `paso${numeroPaso}_${hogar}_${mes}`;
+  const mesNorm = (mes || '').toLowerCase().replace(/\s+/g, '');
+  const hogarNorm = (hogar || '').toLowerCase().replace(/\s+/g, '');
+  return `paso${numeroPaso}_${hogarNorm}_${mesNorm}`;
 }


### PR DESCRIPTION
## Summary
- switch `CaratulaActivaBanner` to `useCabecera`
- adapt Paso 3 and Paso 8 to `useCabecera`
- normalize stored period format
- derive paso keys from `useCabecera`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841875b3438833284018d59aabd2702